### PR TITLE
9 create preliminary gui for ground station

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.slxc
 *.xml
 .vscode
+build
+libs

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ground_station/libs/wxWidgets"]
+	path = ground_station/libs/wxWidgets
+	url = https://github.com/wxWidgets/wxWidgets.git

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # DART - Demonstrator for Autonomous Rapid Transport
 
+To clone the project: run `git clone --recurse-submodules https://github.com/Laagaard/Rocket_Lander.git`
+
+- This will clone both the project and the git submodules it relies on (`wxWidgets`).
+
 This is the codebase for the Florida Tech 2024-2025 Aerospace Engineering capstone design project **DART** (formerly known as "Rocket Lander").
 
 The following is the list of sub-projects included in this project and their respective purposes for the project.
 
 - `diagrams`: contains relevant circuit diagrams, project UML diagrams, etc.
 - `flight_computer`: contains materials related to and used for the flight computer.
-- `ground_station`: contains materials related to and used for ground support equipment (i.e., the ground station).
+- `ground_station`: contains materials related to and used for ground support equipment/software (i.e., the ground station).
 - `simulation`: contains materials related to and used for flight simulation and trajectory/mission planning.

--- a/ground_station/CMakeLists.txt
+++ b/ground_station/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.29) # minimum version of CMake required
+project(ground_station VERSION 1.0) # project name and version
+
+set(wxBUILD_SHARED OFF) # only build wxWidgets static libraries
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "../") # output executable to root `ground_station` directory
+add_subdirectory(libs/wxWidgets) # add wxWidgets as project subdirectory
+add_executable(ground_station ground_station.cpp) # project executable
+target_link_libraries(ground_station wx::net wx::core wx::base) # link relevant wxWidgets libraries

--- a/ground_station/CMakeLists.txt
+++ b/ground_station/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.29) # minimum version of CMake required
 project(ground_station VERSION 1.0) # project name and version
 
 set(wxBUILD_SHARED OFF) # only build wxWidgets static libraries
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "../") # output executable to root `ground_station` directory
 add_subdirectory(libs/wxWidgets) # add wxWidgets as project subdirectory
 add_executable(ground_station ground_station.cpp) # project executable
 target_link_libraries(ground_station wx::net wx::core wx::base) # link relevant wxWidgets libraries

--- a/ground_station/Makefile
+++ b/ground_station/Makefile
@@ -7,4 +7,4 @@ build_dir:
 	@IF exist build ( echo build directory exists ) ELSE ( mkdir build && echo build directory created)
 
 run:
-	@.\ground_station.exe
+	@cd build && .\ground_station.exe

--- a/ground_station/Makefile
+++ b/ground_station/Makefile
@@ -1,0 +1,10 @@
+BUILD_DIR = $(wildcard build/)
+
+build: build_dir
+	cmake --build ${BUILD_DIR}
+
+build_dir:
+	@IF exist build ( echo build directory exists ) ELSE ( mkdir build && echo build directory created)
+
+run:
+	@.\ground_station.exe

--- a/ground_station/README.md
+++ b/ground_station/README.md
@@ -9,8 +9,12 @@
 1. Follow the "Using the CMake GUI" steps [here](https://docs.wxwidgets.org/latest/overview_cmake.html#cmake_options)
 2. Run `cmake -G "Unix Makefiles"`
 
-## Build
+## Build & Run
 * Run `make build`
 
     * This will create a `build` directory for the build files (if one does not already exist)
-    * The executable will be placed in the root `ground_station` directory (makes it easier to track with `git`, since `build` is in the `.gitignore`)
+    * The executable will be placed in the `build` directory
+
+* Run `make run`
+
+    * This will run the application

--- a/ground_station/README.md
+++ b/ground_station/README.md
@@ -1,0 +1,16 @@
+# `ground_station`
+
+## Dependencies
+* `wxWidgets` (taken care of by cloning the `Rocket_Lander` project with `git clone --recurse-submodules https://github.com/Laagaard/Rocket_Lander.git`)
+* [`make`](https://gnuwin32.sourceforge.net/packages/make.htm)
+* [`cmake`](https://cmake.org/download/)
+
+## Setup
+1. Follow the "Using the CMake GUI" steps [here](https://docs.wxwidgets.org/latest/overview_cmake.html#cmake_options)
+2. Run `cmake -G "Unix Makefiles"`
+
+## Build
+* Run `make build`
+
+    * This will create a `build` directory for the build files (if one does not already exist)
+    * The executable will be placed in the root `ground_station` directory (makes it easier to track with `git`, since `build` is in the `.gitignore`)

--- a/ground_station/ground_station.cpp
+++ b/ground_station/ground_station.cpp
@@ -1,0 +1,78 @@
+/*
+Ground station GUI
+*/
+
+#include <wx/wx.h>
+ 
+class MyApp : public wxApp
+{
+public:
+    bool OnInit() override;
+};
+ 
+wxIMPLEMENT_APP(MyApp);
+ 
+class MyFrame : public wxFrame
+{
+public:
+    MyFrame();
+ 
+private:
+    void OnHello(wxCommandEvent& event);
+    void OnExit(wxCommandEvent& event);
+    void OnAbout(wxCommandEvent& event);
+};
+ 
+enum
+{
+    ID_Hello = 1
+};
+ 
+bool MyApp::OnInit()
+{
+    MyFrame *frame = new MyFrame();
+    frame->Show(true);
+    return true;
+}
+ 
+MyFrame::MyFrame()
+    : wxFrame(nullptr, wxID_ANY, "Hello World")
+{
+    wxMenu *menuFile = new wxMenu;
+    menuFile->Append(ID_Hello, "&Hello...\tCtrl-H",
+                     "Help string shown in status bar for this menu item");
+    menuFile->AppendSeparator();
+    menuFile->Append(wxID_EXIT);
+ 
+    wxMenu *menuHelp = new wxMenu;
+    menuHelp->Append(wxID_ABOUT);
+ 
+    wxMenuBar *menuBar = new wxMenuBar;
+    menuBar->Append(menuFile, "&File");
+    menuBar->Append(menuHelp, "&Help");
+ 
+    SetMenuBar( menuBar );
+ 
+    CreateStatusBar();
+    SetStatusText("Welcome to wxWidgets!");
+ 
+    Bind(wxEVT_MENU, &MyFrame::OnHello, this, ID_Hello);
+    Bind(wxEVT_MENU, &MyFrame::OnAbout, this, wxID_ABOUT);
+    Bind(wxEVT_MENU, &MyFrame::OnExit, this, wxID_EXIT);
+}
+ 
+void MyFrame::OnExit(wxCommandEvent& event)
+{
+    Close(true);
+}
+ 
+void MyFrame::OnAbout(wxCommandEvent& event)
+{
+    wxMessageBox("This is a wxWidgets Hello World example",
+                 "About Hello World", wxOK | wxICON_INFORMATION);
+}
+ 
+void MyFrame::OnHello(wxCommandEvent& event)
+{
+    wxLogMessage("Hello world from wxWidgets!");
+}


### PR DESCRIPTION
The `wxWidgets` library has been integrated with the `ground_station` sub-project as a git submodule. The `README.md` in the `ground_station` directory lists all the dependencies, as well as the setup, build, and run instructions. The executable file is too large for git to track it, so the likely easiest method for sharing it will be via Teams (or something similar).